### PR TITLE
Add support for specifying MOM version via command-line argument

### DIFF
--- a/makeic.py
+++ b/makeic.py
@@ -30,9 +30,9 @@ def main():
                         help="""Use MPI to when calculating the regridding weights.
                                This will speed up the calculation considerably.""")
 
-    # Add mom_version argument only if dest_name is MOM
-    parser.add_argument('--mom_version', type=str, default=None,
-                    help="MOM version (e.g., MOM5, MOM6). Required if model_name is MOM or MOM1.")
+    parser.add_argument('--mom_version', type=str, default='MOM5',
+                    help="""MOM version (e.g., MOM5, MOM6). Only used if model_name is MOM or MOM1. 
+                    Defaults to MOM5.""")
 
     args = parser.parse_args()
 
@@ -40,10 +40,6 @@ def main():
         args.model_name == 'NEMO'
     assert args.reanalysis_name == 'GODAS' or args.reanalysis_name == 'ORAS4' or \
         args.reanalysis_name == 'WOA'
-
-    # Ensure mom_version is provided when dest_name is MOM
-    if args.model_name == 'MOM' and args.mom_version is None:
-        parser.error("--mom_version is required when dest_name is MOM")
 
     if os.path.exists(args.output_file):
         print("Output file {} already exists, ".format(args.output_file) + \

--- a/makeic.py
+++ b/makeic.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import sys, os
 import argparse
 import netCDF4 as nc
-
 from regridder import regrid
 
 def main():
@@ -30,12 +29,21 @@ def main():
     parser.add_argument('--use_mpi', action='store_true', default=False,
                         help="""Use MPI to when calculating the regridding weights.
                                This will speed up the calculation considerably.""")
+
+    # Add mom_version argument only if dest_name is MOM
+    parser.add_argument('--mom_version', type=str, default=None,
+                    help="MOM version (e.g., MOM5, MOM6). Required if model_name is MOM or MOM1.")
+
     args = parser.parse_args()
 
     assert args.model_name == 'MOM' or args.model_name == 'MOM1' or \
         args.model_name == 'NEMO'
     assert args.reanalysis_name == 'GODAS' or args.reanalysis_name == 'ORAS4' or \
         args.reanalysis_name == 'WOA'
+
+    # Ensure mom_version is provided when dest_name is MOM
+    if args.model_name == 'MOM' and args.mom_version is None:
+        parser.error("--mom_version is required when dest_name is MOM")
 
     if os.path.exists(args.output_file):
         print("Output file {} already exists, ".format(args.output_file) + \
@@ -73,7 +81,7 @@ def main():
                                        args.model_vgrid,
                                        args.output_file, dest_var, dest_mask=args.model_mask,
                                        month=args.month, regrid_weights=weights,
-                                       use_mpi=args.use_mpi, write_ic=True)
+                                       use_mpi=args.use_mpi, write_ic=True, mom_version=args.mom_version)
         if weights is None:
             return 1
     try:


### PR DESCRIPTION
This PR addresses https://github.com/ACCESS-NRI/access-om3-configs/issues/475 by introducing a --mom-version to support the recent changes made in the `ocean-regrid` repo, PR [6](https://github.com/COSIMA/ocean-regrid/pull/6) . The number of vertical levels in the output file depends on the MOM version, so this option ensures the correct configuration is applied.

Changes:
Added --mom-version option to specify MOM6.